### PR TITLE
Added functions to convert phonetically spelled loshn koydesh to losh…

### DIFF
--- a/yiddish/yiddish.py
+++ b/yiddish/yiddish.py
@@ -499,9 +499,9 @@ def respell_loshn_koydesh(text):
     
     return text
 
-##################################################
-# Convert phonetic spellings to loshn koydesh spellings
-##################################################
+#######################################################
+# convert phonetic spellings to loshn-koydesh spellings
+#######################################################
 
 # Note: input text WILL become precombined
 def spell_loshn_koydesh(text):
@@ -518,6 +518,9 @@ def spell_loshn_koydesh(text):
             # (e.g., to avoid סעודה to סודע to סױדע)
             text = re.sub(r'(?<![אאַאָבבֿגדהװווּזחטייִײײַױכּכךלמםנןסעפּפפֿףצץקרששׂתּתΔ])' + key + r'(?![\'אאַאָבבֿגדהװווּזחטייִײײַױכּכךלמםנןסעפּפפֿףצץקרששׂתּת])', 'Δ' + replacement, text)
     
+    # remove the added Δ
+    text = re.sub('Δ', '', text)
+
     return text
 
 #######################################
@@ -643,14 +646,14 @@ def desovietify(text):
     text = 'Γ'.join(text)
     text = 'Γ' + text + 'Γ'
 
-    #replace unpointed alef with pasekh alef when not followed by vowels. 
-    #Unpointed aleph, if not followed by another vowel, is alway pasekh alef in Soviet orthography.
-    text = re.sub('א(?![י|ײ|ײַ|ױ|ו])', 'אַ', text)
+    # replace unpointed alef with pasekh alef when not followed by vowels. 
+    # (unpointed alef, if not followed by a vov/yud-based vowel, is alway pasekh alef in Soviet orthography)
+    text = re.sub('א(?![י|יִ|ײ|ײַ|וּ|ױ|ו])', 'אַ', text)
 
-    #replace unpointed pey with fey
-    text = re.sub('פ', 'פֿ', text)
+    # replace unpointed pey with fey
+    text = re.sub('פ', 'פֿ', text)
 
-    #replace final kaf, nun, mem, tsadi, fey with long forms
+    # replace final kof, mem, nun, tsadek, fey with long forms
     text = re.sub('כ(?=Γ)', 'ך', text)
     text = re.sub('מ(?=Γ)', 'ם', text)
     text = re.sub('נ(?=Γ)', 'ן', text)

--- a/yiddish/yiddish.py
+++ b/yiddish/yiddish.py
@@ -658,7 +658,15 @@ def desovietify(text):
     text = re.sub('מ(?=Γ)', 'ם', text)
     text = re.sub('נ(?=Γ)', 'ן', text)
     text = re.sub('צ(?=Γ)', 'ץ', text)
-    text = re.sub('פֿ(?=Γ)', 'ף', text)
+    text = re.sub('פֿ(?=Γ)', 'ף', text)
+
+    # replace oyf, bay
+    text = re.sub('(?<=Γ)אַף(?=Γ)', 'אױף', text)
+    text = re.sub('(?<=Γ)אַפֿן(?=Γ)', 'אױפֿן', text)
+    text = re.sub('(?<=Γ)אוף(?=Γ)', 'אױף', text)
+    text = re.sub('(?<=Γ)אופֿ', 'אױפֿ', text)
+    text = re.sub('(?<=Γ)באַ(?=Γ)', 'בײַ', text)
+    text = re.sub('(?<=Γ)באַם(?=Γ)', 'בײַם', text)
 
     text = spell_loshn_koydesh(text)
 

--- a/yiddish/yiddish.py
+++ b/yiddish/yiddish.py
@@ -471,6 +471,7 @@ def respell_loshn_koydesh(text):
                 replacement = lk[key][1]
             else:
                 replacement = lk[key][0]
+            
                 
             # replace whole words (separated by spaces & punctuation, but not
             # followed by an apostrophe);
@@ -497,7 +498,28 @@ def respell_loshn_koydesh(text):
         text = re.sub(r'(?<![אאַאָבבֿגדהװווּזחטייִײײַױכּכךלמםנןסעפּפפֿףצץקרששׂתּת])' + key + r'(?![\'אאַאָבבֿגדהװווּזחטייִײײַױכּכךלמםנןסעפּפפֿףצץקרששׂתּת])', mistakes[key], text)
     
     return text
+
+##################################################
+# Convert phonetic spellings to loshn koydesh spellings
+##################################################
+
+# Note: input text WILL become precombined
+def spell_loshn_koydesh(text):
+    text = replace_with_precombined(text)
+    # loop over keys, in reverse order from longest keys to shortest
+    for key in sorted(list(reverse_lk.keys()), key=len, reverse=True):
+        # skip Germanic homophones
+        if key not in semitic_germanic_homophones:
+            replacement = reverse_lk[key]
+                
+            # replace whole words (separated by spaces & punctuation, but not
+            # followed by an apostrophe);
+            # also, append a Δ to the respelling so it's not accidentally overwritten
+            # (e.g., to avoid סעודה to סודע to סױדע)
+            text = re.sub(r'(?<![אאַאָבבֿגדהװווּזחטייִײײַױכּכךלמםנןסעפּפפֿףצץקרששׂתּתΔ])' + key + r'(?![\'אאַאָבבֿגדהװווּזחטייִײײַױכּכךלמםנןסעפּפפֿףצץקרששׂתּת])', 'Δ' + replacement, text)
     
+    return text
+
 #######################################
 # convert YIVO orthography into Hasidic
 
@@ -613,3 +635,32 @@ def hasidify(text):
     
     return text
     
+def desovietify(text):
+    text = replace_with_precombined(text)
+    text = re.split(r"([^אאַאָבבֿגדהווּװױזחטייִײײַכּכךלמםנןסעפפּפֿףצץקרששׂתּתA-Za-z'])", text)
+    
+    # add 'Γ' as a word/token boundary symbol
+    text = 'Γ'.join(text)
+    text = 'Γ' + text + 'Γ'
+
+    #replace unpointed alef with pasekh alef when not followed by vowels. 
+    #Unpointed aleph, if not followed by another vowel, is alway pasekh alef in Soviet orthography.
+    text = re.sub('א(?![י|ײ|ײַ|ױ|ו])', 'אַ', text)
+
+    #replace unpointed pey with fey
+    text = re.sub('פ', 'פֿ', text)
+
+    #replace final kaf, nun, mem, tsadi, fey with long forms
+    text = re.sub('כ(?=Γ)', 'ך', text)
+    text = re.sub('מ(?=Γ)', 'ם', text)
+    text = re.sub('נ(?=Γ)', 'ן', text)
+    text = re.sub('צ(?=Γ)', 'ץ', text)
+    text = re.sub('פֿ(?=Γ)', 'ף', text)
+
+    text = spell_loshn_koydesh(text)
+
+    # remove Greek letters
+    text = text.replace('Δ', '')
+    text = text.replace('Γ', '')
+
+    return text


### PR DESCRIPTION
Adds a function to convert Soviet orthography to YIVO orthography, along with a function that converts phonetically spelled Loshn Koydesh to Hebrew/Aramaic orthography.

Sample input: 

כאװײרימ, זינט דער אָקטיאָבער־רעװאָלוציע באהאנדלענ מיר צומ דריטנ מאָל די נאציאָנאלע פראגע: דעמ ערשטנ מאָל אפנ VIII צוזאמענפאָר, דעמ צװײטנ -- אפנ X אונ דעמ דריטנ -- אפנ XII. צי איז עס ניט אמאָל א סימענ, אז עטװאָס האָט זיכ פּרינציפּיעל געענדערט אינ אונדזערע מײנונגענ װעגן דער נאציאָנאַלער פראגע? נײנ. דער פּרינציפּיעלער קוק אפ דער נאציאָנאלער פראַגע איז געבליבנ דער זעלביקער, װי ביז אָקטיאָבער, אונ נאָכ דעמ. נאָר זינט דעמ X צוזאמענפאָר האָט זיכ געענדערט די אינטערנאציאָנאלע סיטואציע אינ דער הינזיכט, װאָס עס האָט זיכ פארשטארקט דאָס ספּעציפישע געװיכט פונ יענע שװערע רעזערװנ פונ דער רעװאָליוציע װעלכע די מיזרעכ-לענדער שטעלנ מיט זיכ איצט פאָר. דאָס איז ערשטנס. צװײטנס, האָט אונדזער פּארטײ זינט דעמ X צוזאמענפאָר אױכ געהאט אינ אינערלעכער לאגע אײניקע ענדערונגענ אינ פארבינדונג מיטנ נעפּ. די אלע נײַע פאקטאָרנ מוז מען דיסקוטירנ, אונטערציִענ אונטער זײ אַ סאכאקל. אָט אינ דער הינזיכט קאָנ מענ רײדנ װעגנ א נײַער שטעלונג פונ דער נאציִאָנאלער פראגע אפ דעמ XII צוזאמענפאָר.

Sample output:

חבֿרים, זינט דער אָקטיאָבער־רעװאָלוציע באַהאַנדלען מיר צום דריטן מאָל די נאַציאָנאַלע פֿראַגע: דעם ערשטן מאָל אַפֿן VIII צוזאַמענפֿאָר, דעם צװײטן -- אַפֿן X און דעם דריטן -- אַפֿן XII. צי איז עס ניט אַמאָל אַ סימן, אַז עטװאָס האָט זיך פּרינציפּיעל געענדערט אין אונדזערע מײנונגען װעגן דער נאַציאָנאַלער פֿראַגע? נײן. דער פּרינציפּיעלער קוק אַף דער נאַציאָנאַלער פֿראַגע איז געבליבן דער זעלביקער, װי ביז אָקטיאָבער, און נאָך דעם. נאָר זינט דעם X צוזאַמענפֿאָר האָט זיך געענדערט די אינטערנאַציאָנאַלע סיטואַציע אין דער הינזיכט, װאָס עס האָט זיך פֿאַרשטאַרקט דאָס ספּעציפֿישע געװיכט פֿון יענע שװערע רעזערװן פֿון דער רעװאָליוציע װעלכע די מיזרח-לענדער שטעלן מיט זיך איצט פֿאָר. דאָס איז ערשטנס. צװײטנס, האָט אונדזער פּאַרטײ זינט דעם X צוזאַמענפֿאָר אױך געהאַט אין אינערלעכער לאַגע אײניקע ענדערונגען אין פֿאַרבינדונג מיטן נעפּ. די אַלע נײַע פֿאַקטאָרן מוז מען דיסקוטירן, אונטערציִען אונטער זײ אַ סך־הכּל. אָט אין דער הינזיכט קאָן מען רײדן װעגן אַ נײַער שטעלונג פֿון דער נאַציִאָנאַלער פֿראַגע אַף דעם XII צוזאַמענפֿאָר.


The conversion to LK orthography still has the same issues as detransliteration. Lemoshl:
```
import yiddish

output = ''

string = 'כאװײרימ, זינט דער אָקטיאָבער־רעװאָלוציע באהאנדלענ מיר צומ דריטנ מאָל די נאציאָנאלע פראגע: דעמ ערשטנ מאָל אפנ VIII צוזאמענפאָר, דעמ צװײטנ -- אפנ X אונ דעמ דריטנ -- אפנ XII. צי איז עס ניט אמאָל א סימענ, אז עטװאָס האָט זיכ פּרינציפּיעל געענדערט אינ אונדזערע מײנונגענ װעגן דער נאציאָנאַלער פראגע? נײנ. דער פּרינציפּיעלער קוק אפ דער נאציאָנאלער פראַגע איז געבליבנ דער זעלביקער, װי ביז אָקטיאָבער, אונ נאָכ דעמ. נאָר זינט דעמ X צוזאמענפאָר האָט זיכ געענדערט די אינטערנאציאָנאלע סיטואציע אינ דער הינזיכט, װאָס עס האָט זיכ פארשטארקט דאָס ספּעציפישע געװיכט פונ יענע שװערע רעזערװנ פונ דער רעװאָליוציע װעלכע די מיזרעכ-לענדער שטעלנ מיט זיכ איצט פאָר. דאָס איז ערשטנס. צװײטנס, האָט אונדזער פּארטײ זינט דעמ X צוזאמענפאָר אױכ געהאט אינ אינערלעכער לאגע אײניקע ענדערונגענ אינ פארבינדונג מיטנ נעפּ. די אלע נײַע פאקטאָרנ מוז מען דיסקוטירנ, אונטערציִענ אונטער זײ אַ סאכאקל. אָט אינ דער הינזיכט קאָנ מענ רײדנ װעגנ א נײַער שטעלונג פונ דער נאציִאָנאלער פראגע אפ דעמ XII צוזאמענפאָר.'
output += yiddish.desovietify(string)
output += '\n\n'

string =  "ריװקעס שכײנעס זענענ אקשאָנעסדיק"
output += yiddish.desovietify(string)
output += '\n\n'

string = "Rivkes shkheynes zenen akshonesdik"
output += yiddish.detransliterate(string, loshn_koydesh=True)


print(output)
```

Output:
```
רבֿקהס שכנהס זענען אַקשאָנעסדיק

רבֿקהס שכנהס זענען אַקשאָנעסדיק

```

I'm also unsure if it makes sense to convert the אַפֿן to אױפֿן ...